### PR TITLE
Add build configuration for MT7628 firmware

### DIFF
--- a/build.config
+++ b/build.config
@@ -1,0 +1,277 @@
+### Target Vendor/Product (support only Ralink RT3883/MT7620/MT7621/MT7628)
+CONFIG_VENDOR=XIAOMI
+CONFIG_PRODUCT=MT7628
+
+### Target ProductID (board select, max 23 ASCII symbols)
+CONFIG_FIRMWARE_PRODUCT_ID="MI-4A_100M"
+
+############################################################
+### Linux kernel configuration
+############################################################
+
+### Enable MT7628 CPU sleep mode (downclock to 100MHz on idle)
+#CONFIG_FIRMWARE_CPU_SLEEP=y
+
+### Kernel driver select for WiFi AP 5GHz
+### 3.0 = MT7612E v3.0.4.0
+CONFIG_FIRMWARE_WIFI5_DRIVER=3.0
+
+### Kernel driver select for WiFi AP 2.4GHz
+### 4.0 = MT7628 v4.0.1.3
+CONFIG_FIRMWARE_WIFI2_DRIVER=4.0
+
+### Enable IPv6 support
+CONFIG_FIRMWARE_ENABLE_IPV6=y
+
+### Enable USB support
+CONFIG_FIRMWARE_ENABLE_USB=n
+
+### Enable FAT/FAT32 filesystem support. ~0.1MB
+CONFIG_FIRMWARE_ENABLE_FAT=n
+
+### Enable exFAT (FAT/FAT32 too) filesystem support. ~0.12MB
+CONFIG_FIRMWARE_ENABLE_EXFAT=n
+
+### Enable EXT2 filesystem support. ~0.1MB
+CONFIG_FIRMWARE_ENABLE_EXT2=y
+
+### Enable EXT3 filesystem support. ~0.2MB
+CONFIG_FIRMWARE_ENABLE_EXT3=y
+
+### Enable EXT4 (EXT3/2 too) filesystem support. ~0.4MB
+CONFIG_FIRMWARE_ENABLE_EXT4=y
+
+### Enable XFS filesystem support. ~0.6MB
+#CONFIG_FIRMWARE_ENABLE_XFS=n
+
+### Enable FUSE (filesystems in userspace) support. ~0.1MB
+CONFIG_FIRMWARE_ENABLE_FUSE=y
+
+### Enable swap files/partitions support. ~0.05MB
+CONFIG_FIRMWARE_ENABLE_SWAP=y
+
+### Include UVC camera modules. ~0.2MB
+CONFIG_FIRMWARE_INCLUDE_UVC=n
+
+### Include USB-HID modules. ~0.2MB
+CONFIG_FIRMWARE_INCLUDE_HID=n
+
+### Include USB-Serial modules (e.g. pl2303). ~0.03MB
+CONFIG_FIRMWARE_INCLUDE_SERIAL=n
+
+### Include USB-Audio modules ~0.46MB
+#CONFIG_FIRMWARE_INCLUDE_AUDIO=n
+
+### Include XFRM (IPsec) modules & iptables extension ~ 0.2MB
+#CONFIG_FIRMWARE_INCLUDE_XFRM=y
+
+### Include network QoS scheduling modules. ~0.2MB
+#CONFIG_FIRMWARE_INCLUDE_QOS=y
+
+### Include IMQ module for shapers (a bit of performance degradation). ~0.02MB
+#CONFIG_FIRMWARE_INCLUDE_IMQ=y
+
+### Include IFB module for shapers. ~0.03MB
+#CONFIG_FIRMWARE_INCLUDE_IFB=y
+
+### Include IPSet utility and kernel modules. ~0.4MB
+CONFIG_FIRMWARE_INCLUDE_IPSET=y
+
+### Include NFSv3 server. ~0.6MB
+CONFIG_FIRMWARE_INCLUDE_NFSD=n
+
+### Include NFSv3 client. ~0.5MB
+CONFIG_FIRMWARE_INCLUDE_NFSC=n
+
+### Include CIFS (SMB) client. ~0.2MB
+CONFIG_FIRMWARE_INCLUDE_CIFS=y
+
+### Include Shortcut Forward Engine
+CONFIG_FIRMWARE_INCLUDE_SHORTCUT_FE=y
+
+############################################################
+### Userspace configuration
+############################################################
+
+### Include WebUI international resources. Increased firmware size
+#CONFIG_FIRMWARE_INCLUDE_LANG_BR=y
+#CONFIG_FIRMWARE_INCLUDE_LANG_CN=y
+#CONFIG_FIRMWARE_INCLUDE_LANG_CZ=y
+#CONFIG_FIRMWARE_INCLUDE_LANG_DA=y
+#CONFIG_FIRMWARE_INCLUDE_LANG_DE=y
+#CONFIG_FIRMWARE_INCLUDE_LANG_ES=y
+#CONFIG_FIRMWARE_INCLUDE_LANG_FI=y
+#CONFIG_FIRMWARE_INCLUDE_LANG_FR=y
+#CONFIG_FIRMWARE_INCLUDE_LANG_NO=y
+#CONFIG_FIRMWARE_INCLUDE_LANG_PL=y
+CONFIG_FIRMWARE_INCLUDE_LANG_RU=y
+#CONFIG_FIRMWARE_INCLUDE_LANG_SV=y
+#CONFIG_FIRMWARE_INCLUDE_LANG_UK=y
+
+### Include NTFS-3G FUSE driver (instead of Paragon "ufsd"). ~0.4MB
+CONFIG_FIRMWARE_INCLUDE_NTFS_3G=n
+
+### Include LPR printer daemon. ~0.12MB
+CONFIG_FIRMWARE_INCLUDE_LPRD=n
+
+### Include ASUS/Eltima USB-over-Ethernet printer daemon. ~0.05MB
+CONFIG_FIRMWARE_INCLUDE_U2EC=n
+
+### Include USB-over-IP daemon. ~0.05MB
+#CONFIG_FIRMWARE_INCLUDE_USBIP=y
+
+### Include "tcpdump" utility. ~0.6MB
+CONFIG_FIRMWARE_INCLUDE_TCPDUMP=y
+
+### Include "socat" utility ~0.3MB
+#CONFIG_FIRMWARE_INCLUDE_SOCAT=y
+
+### Include "ndisc6" and "rdisc6" utilities ~0.27MB
+#CONFIG_FIRMWARE_INCLUDE_NDISC6_RDISC6=y
+
+### Include "hdparm" utility (allow set HDD spindown timeout and APM). ~0.1MB
+CONFIG_FIRMWARE_INCLUDE_HDPARM=n
+
+### Include "parted" utility (allow make GPT partitions). ~0.3MB
+CONFIG_FIRMWARE_INCLUDE_PARTED=n
+
+### Include SMB (and WINS) server. ~1.5MB
+CONFIG_FIRMWARE_INCLUDE_SMBD=n
+
+### Include WINS server only. ~0.4MB
+#CONFIG_FIRMWARE_INCLUDE_WINS=y
+
+### Include syslog for SMB and WINS server. ~0.3MB
+CONFIG_FIRMWARE_INCLUDE_SMBD_SYSLOG=n
+
+### Include testparm for SMB server. ~0.2MB
+#CONFIG_FIRMWARE_INCLUDE_TESTPARM=y
+
+### Include FTP server. ~0.2MB
+CONFIG_FIRMWARE_INCLUDE_FTPD=n
+#CONFIG_FIRMWARE_INCLUDE_FTPD_SSL=y
+
+### Include alternative L2TP control client RP-L2TP. ~0.1MB
+CONFIG_FIRMWARE_INCLUDE_RPL2TP=y
+
+### Include EAP-TTLS and EAP-PEAP authentication support. openssl ~1.2MB, wpa_supplicant +0.04MB
+CONFIG_FIRMWARE_INCLUDE_EAP_PEAP=y
+
+### Include HTTPS support for DDNS client. openssl ~1.2MB
+CONFIG_FIRMWARE_INCLUDE_DDNS_SSL=y
+
+### Include HTTPS support. openssl ~1.2MB
+CONFIG_FIRMWARE_INCLUDE_HTTPS=y
+
+### Include sftp-server. openssl ~1.2MB, sftp-server ~0.06MB
+CONFIG_FIRMWARE_INCLUDE_SFTP=y
+
+### Include dropbear SSH. ~0.3MB
+CONFIG_FIRMWARE_INCLUDE_DROPBEAR=y
+
+### Make the dropbear symmetrical ciphers and hashes faster. ~0.06MB
+CONFIG_FIRMWARE_INCLUDE_DROPBEAR_FAST_CODE=y
+
+### Include OpenSSH instead of dropbear. openssl ~1.2MB, openssh ~1.0MB
+#CONFIG_FIRMWARE_INCLUDE_OPENSSH=y
+
+### Include OpenVPN. IPv6 required. openssl ~1.2MB, openvpn ~0.4MB
+CONFIG_FIRMWARE_INCLUDE_OPENVPN=y
+
+### Include Wireguard VPN module and utilite
+CONFIG_FIRMWARE_INCLUDE_WIREGUARD=y
+
+### Include AmneziaWG kernel module
+CONFIG_FIRMWARE_INCLUDE_AMNEZIAWG=y
+
+### Include Elliptic Curves (EC) to openssl library. ~0.1MB
+CONFIG_FIRMWARE_INCLUDE_OPENSSL_EC=y
+
+### Include "openssl" executable for generate certificates. ~0.4MB
+CONFIG_FIRMWARE_INCLUDE_OPENSSL_EXE=y
+
+### Include xUPNPd IPTV mediaserver. ~0.3MB
+CONFIG_FIRMWARE_INCLUDE_XUPNPD=y
+
+### Include Minidlna UPnP mediaserver. ~1.6MB
+CONFIG_FIRMWARE_INCLUDE_MINIDLNA=y
+
+### Include Transmission torrent. openssl ~1.2MB, transmission ~1.5MB
+CONFIG_FIRMWARE_INCLUDE_TRANSMISSION=n
+
+### Include Transmission-Web-Control (advanced WebUI). ~0.8MB
+CONFIG_FIRMWARE_INCLUDE_TRANSMISSION_WEB_CONTROL=n
+
+### Include Aria2 download manager. openssl ~1.2MB, aria2 ~3.5MB
+#CONFIG_FIRMWARE_INCLUDE_ARIA=n
+
+### Include Aria2 WEB control. ~0.7MB
+#CONFIG_FIRMWARE_INCLUDE_ARIA_WEB_CONTROL=n
+
+### Include TOR proxy ~2.8MB
+#CONFIG_FIRMWARE_INCLUDE_TOR=y
+
+### Include GeoIP database info for TOR proxy ~0.7MB
+#CONFIG_FIRMWARE_INCLUDE_TOR_GEOIP=y
+
+### Include IPv6 GeoIP database info for TOR proxy ~0.6MB
+#CONFIG_FIRMWARE_INCLUDE_TOR_GEOIPV6=y
+
+### Include OBFS4 for TOR ~6.1MB
+#CONFIG_FIRMWARE_INCLUDE_OBFS4=y
+
+### Include Privoxy proxy ~0.3MB
+CONFIG_FIRMWARE_INCLUDE_PRIVOXY=y
+
+### Include DNSCrypt proxy ~0.5MB
+CONFIG_FIRMWARE_INCLUDE_DNSCRYPT=y
+
+### Include Stubby DNS-over-TLS (DoT) ~0.5MB
+CONFIG_FIRMWARE_INCLUDE_STUBBY=y
+
+### Include doh_proxy DNS-over-HTTPS (DoH) ~0.4MB
+CONFIG_FIRMWARE_INCLUDE_DOH=y
+
+### Include Curl support ~0.15MB
+CONFIG_FIRMWARE_INCLUDE_CURL=y
+
+### Include QUIC support in Curl, openssl 3.5 required ~0.4 MB
+CONFIG_FIRMWARE_INCLUDE_QUIC=y
+
+### Include QUIC support in Curl using ngtcp2, openssl 3.5 required ~0.5 MB
+#CONFIG_FIRMWARE_INCLUDE_QUIC_NGTCP2=y
+
+### Include other versions of openssl instead of the default 3.0
+### openssl 1.0.2u
+#CONFIG_FIRMWARE_INCLUDE_OPENSSL_10=y
+### openssl 1.1.1w
+#CONFIG_FIRMWARE_INCLUDE_OPENSSL_11=y
+### openssl 3.5
+#CONFIG_FIRMWARE_INCLUDE_OPENSSL_35=y
+
+### Include WPAD support
+CONFIG_FIRMWARE_INCLUDE_WPAD=y
+
+### Include compressed memory support
+CONFIG_FIRMWARE_INCLUDE_ZRAM=y
+
+### Add adb package
+#CONFIG_FIRMWARE_INCLUDE_ADB=y
+
+### Include LUA support ~0.2MB
+CONFIG_FIRMWARE_INCLUDE_LUA=y
+
+### Include EoIP Ethernet Tunnels over IP ~0.01MB
+CONFIG_FIRMWARE_INCLUDE_EOIP=y
+
+### Include KMS Activation support ~0.06MB
+#CONFIG_FIRMWARE_INCLUDE_VLMCSD=y
+
+### Include iPerf3 support ~0.13MB
+CONFIG_FIRMWARE_INCLUDE_IPERF3=y
+
+### Include NFQWS support ~0.1MB
+CONFIG_FIRMWARE_INCLUDE_NFQWS=y
+
+### Reduce trx image size
+#CONFIG_CC_OPTIMIZE_FOR_SIZE=y


### PR DESCRIPTION
This configuration file sets up various firmware options for the target product MT7628, including enabling/disabling specific drivers, filesystem supports, and utilities.