### PR TITLE
Change repository URLs from GitLab to GitHub

### DIFF
--- a/variables
+++ b/variables
@@ -1,7 +1,7 @@
-PADAVAN_REPO="https://gitlab.com/hadzhioglu/padavan-ng.git"
+PADAVAN_REPO="https://github.com/nilabsent/padavan-ng.git"
 PADAVAN_BRANCH="master"
 PADAVAN_COMMIT="HEAD"
-PADAVAN_TOOLCHAIN_URL="https://gitlab.com/api/v4/projects/hadzhioglu%2Fpadavan-ng/packages/generic/toolchain/latest/toolchain.tzst"
+PADAVAN_TOOLCHAIN_URL="https://github.com/nilabsent/padavan-ng/tree/57e8f280bd22103135148129f34b6eed56fdf437/toolchain"
 
 PADAVAN_THEMES_REPO="https://gitlab.com/hadzhioglu/padavan-themes.git"
 #PADAVAN_THEMES_REPO="https://gitlab.com/hadzhioglu/padavan-themes-lite.git"


### PR DESCRIPTION
Updated repository and toolchain URLs to point to GitHub.